### PR TITLE
Change jailer's 'unshare' + 'fork' to 'clone'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,8 +407,8 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.4.0"
-source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.4.0-1#9a5fbd29ad9011aa1e004849de7f28b2b3002b01"
+version = "0.5.0"
+source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.5.0-1#4569d3f5b7746b66fc58a14cd05e5dbf9368932b"
 dependencies = [
  "versionize",
  "versionize_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ panic = "abort"
 lto = true
 
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.4.0-1", features = ["fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.5.0-1", features = ["fam-wrappers"] }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 libc = ">=0.2.39"
 vm-memory = { path = "../vm-memory" }

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 
 utils = { path = "../utils"}

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -4,7 +4,6 @@
 pub mod device;
 pub mod event_handler;
 pub mod persist;
-#[cfg(test)]
 pub mod test_utils;
 mod utils;
 

--- a/src/devices/src/virtio/balloon/test_utils.rs
+++ b/src/devices/src/virtio/balloon/test_utils.rs
@@ -4,10 +4,12 @@
 use std::u32;
 
 use crate::virtio::test_utils::VirtQueue;
+#[cfg(test)]
 use crate::virtio::{
     balloon::NUM_QUEUES, Balloon, IrqType, DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX,
 };
 
+#[cfg(test)]
 pub fn invoke_handler_for_queue_event(b: &mut Balloon, queue_index: usize) {
     assert!(queue_index < NUM_QUEUES);
     // Trigger the queue event.

--- a/src/devices/src/virtio/balloon/test_utils.rs
+++ b/src/devices/src/virtio/balloon/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc(hidden)]
+
 use std::u32;
 
 use crate::virtio::test_utils::VirtQueue;

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -5,7 +5,6 @@ pub mod device;
 pub mod event_handler;
 pub mod persist;
 pub mod request;
-#[cfg(test)]
 pub mod test_utils;
 
 pub use self::device::{Block, CacheType};

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -1,7 +1,9 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::virtio::{Block, CacheType, IrqType, Queue};
+#[cfg(test)]
+use crate::virtio::IrqType;
+use crate::virtio::{Block, CacheType, Queue};
 use rate_limiter::RateLimiter;
 use utils::tempfile::TempFile;
 
@@ -33,15 +35,6 @@ pub fn default_block_with_path(path: String) -> Block {
     .unwrap()
 }
 
-pub fn invoke_handler_for_queue_event(b: &mut Block) {
-    // Trigger the queue event.
-    b.queue_evts[0].write(1).unwrap();
-    // Handle event.
-    b.process_queue_event();
-    // Validate the queue operation finished successfully.
-    assert!(b.irq_trigger.has_pending_irq(IrqType::Vring));
-}
-
 pub fn set_queue(blk: &mut Block, idx: usize, q: Queue) {
     blk.queues[idx] = q;
 }
@@ -52,4 +45,14 @@ pub fn set_rate_limiter(blk: &mut Block, rl: RateLimiter) {
 
 pub fn rate_limiter(blk: &mut Block) -> &RateLimiter {
     &blk.rate_limiter
+}
+
+#[cfg(test)]
+pub fn invoke_handler_for_queue_event(b: &mut Block) {
+    // Trigger the queue event.
+    b.queue_evts[0].write(1).unwrap();
+    // Handle event.
+    b.process_queue_event();
+    // Validate the queue operation finished successfully.
+    assert!(b.irq_trigger.has_pending_irq(IrqType::Vring));
 }

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc(hidden)]
+
 #[cfg(test)]
 use crate::virtio::IrqType;
 use crate::virtio::{Block, CacheType, Queue};

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -16,7 +16,6 @@ pub mod device;
 pub mod event_handler;
 pub mod persist;
 mod tap;
-#[cfg(test)]
 pub mod test_utils;
 
 pub use self::device::Net;

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{mem, result};
 
+#[cfg(test)]
 use crate::virtio::net::device::vnet_hdr_len;
 use crate::virtio::net::tap::{Error, IfReqBuilder, Tap};
 use crate::virtio::test_utils::VirtQueue;

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc(hidden)]
+
 use std::fs::File;
 use std::os::raw::c_ulong;
 use std::os::unix::ffi::OsStrExt;

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc(hidden)]
+
 use std::marker::PhantomData;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc(hidden)]
+
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use crate::virtio::test_utils::VirtQueue as GuestQ;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,7 +18,7 @@ vm-memory = { path = "../vm-memory" }
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }


### PR DESCRIPTION
The exec_into_new_pid_ns() function of the jailer should dispatch a new
process inside a new PID namespace.
It was done using unshare to a new PID namespace, then calling fork to
dispatch a process inside that namespace.
Changed it According to the TODO message - replaced this combo
with a single call to clone with the CLONE_NEWPID flag, in order to
squeeze startup latency.

Besides the actual change inside the function, changed the jailer.md
documentation to fit the change.

Signed-off-by: razn <rezwele@gmail.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
